### PR TITLE
feat: add native bridge support for ARM apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Access and control the Android emulator directly in your web browser with the in
 - **scrcpy Support:** Mirror the emulator screen using scrcpy for a seamless user experience.
 - **Optimized Performance:** Utilizes native CPU capabilities for efficient emulation.
 - **Multi-Architecture Support:** Runs natively on both **x86** and **arm64** CPU architectures.
+- **Native Bridge for ARM Apps:** Bundled libndk translation layer allows running ARM-only APKs on the x86 system image.
 - **Docker Integration:** Easily deploy the Android emulator within a Docker container.
 - **Easy Setup:** Simple Docker commands to build and run the emulator.
 - **Supervisor Management:** Manages emulator processes with Supervisor for reliability.

--- a/first-boot.sh
+++ b/first-boot.sh
@@ -70,6 +70,31 @@ adb push gapps-11/framework /system
 adb push gapps-11/app /system
 adb push gapps-11/priv-app /system
 
+# Install native bridge libraries for ARM compatibility
+echo "Installing native bridge ..."
+curl -L -o ndk-translation.tar.gz https://github.com/iwei20/libndk_extracted/archive/refs/heads/main.tar.gz
+mkdir ndk-translation
+tar -xf ndk-translation.tar.gz -C ndk-translation --strip-components=1
+for dir in bin etc lib lib64; do
+  if [ -d ndk-translation/system/$dir ]; then
+    adb push ndk-translation/system/$dir /system/
+  fi
+done
+adb shell 'cat >> /system/build.prop <<"EOF"
+ro.dalvik.vm.native.bridge=libndk_translation.so
+ro.enable.native.bridge.exec=1
+ro.enable.native.bridge.exec64=1
+ro.vendor.enable.native.bridge.exec=1
+ro.vendor.enable.native.bridge.exec64=1
+ro.ndk_translation.version=0.2.3
+ro.dalvik.vm.isa.arm=x86
+ro.dalvik.vm.isa.arm64=x86_64
+ro.product.cpu.abilist=x86_64,x86,armeabi-v7a,armeabi,arm64-v8a
+ro.product.cpu.abilist32=x86,armeabi-v7a,armeabi
+ro.product.cpu.abilist64=x86_64,arm64-v8a
+EOF'
+rm -rf ndk-translation ndk-translation.tar.gz
+
 echo "Root Script Starting..."
 
 # Root the VM

--- a/start-emulator.sh
+++ b/start-emulator.sh
@@ -6,4 +6,4 @@ if [ -f /data/.first-boot-done ]; then
 fi
 
 # Start the emulator with the appropriate ramdisk.img
-/opt/android-sdk/emulator/emulator -avd android -nojni -netfast -writable-system -no-window -no-audio -no-boot-anim -skip-adb-auth -gpu swiftshader_indirect -no-snapshot -no-metrics $RAMDISK -qemu -m ${RAM_SIZE:-4096}
+/opt/android-sdk/emulator/emulator -avd android -nojni -netfast -writable-system -no-window -no-audio -no-boot-anim -skip-adb-auth -gpu swiftshader_indirect -no-snapshot -no-metrics -feature AllowlistedNativeBridge $RAMDISK -qemu -m ${RAM_SIZE:-4096}


### PR DESCRIPTION
## Summary
- install libndk native bridge during first boot to run ARM-only APKs
- enable native bridge feature in emulator startup
- document ARM app support in README

## Testing
- `bash -n first-boot.sh`
- `bash -n start-emulator.sh`


------
fixing  #5 