### PR TITLE
Add shared volume to mount host folder in Android emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ To simplify the setup process, you can use the provided [docker-compose.yml](htt
 
     > **Note:** This command launches the Android emulator and web interface. First boot takes some time to initialize. Once ready, the device will appear in the web interface at http://localhost:8000.
 
+3. **Use the Shared Folder (optional):**
+
+    Any files placed in the `./shared` directory on the host will be available inside Android at `/mnt/shared`.
+
 ## 📡 **Usage**
 
 ### 🌐 Use the Web Interface to Access the Emulator

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     volumes:
       - ./data:/data
       - ./extras:/extras
+      - ./shared:/shared
     environment:
       - DNS=one.one.one.one
       - RAM_SIZE=8192

--- a/first-boot.sh
+++ b/first-boot.sh
@@ -10,6 +10,9 @@ apply_settings() {
     sleep 5
   done
   adb root
+  adb wait-for-device
+  adb shell "mkdir -p /mnt/shared"
+  adb shell "mount -t 9p -o trans=virtio,version=9p2000.L shared /mnt/shared || mount -t virtiofs shared /mnt/shared"
   adb shell settings put global window_animation_scale 0
   adb shell settings put global transition_animation_scale 0
   adb shell settings put global animator_duration_scale 0

--- a/start-emulator.sh
+++ b/start-emulator.sh
@@ -6,4 +6,4 @@ if [ -f /data/.first-boot-done ]; then
 fi
 
 # Start the emulator with the appropriate ramdisk.img
-/opt/android-sdk/emulator/emulator -avd android -nojni -netfast -writable-system -no-window -no-audio -no-boot-anim -skip-adb-auth -gpu swiftshader_indirect -no-snapshot -no-metrics $RAMDISK -qemu -m ${RAM_SIZE:-4096}
+/opt/android-sdk/emulator/emulator -avd android -nojni -netfast -writable-system -no-window -no-audio -no-boot-anim -skip-adb-auth -gpu swiftshader_indirect -no-snapshot -no-metrics -selinux permissive $RAMDISK -qemu -m ${RAM_SIZE:-4096} -qemu -virtfs local,path=/shared,security_model=none,mount_tag=shared


### PR DESCRIPTION
## Summary
- Mount `./shared` as a volume in `docker-compose.yml`
- Start emulator with virtiofs share and permissive SELinux mode
- Mount shared host folder inside Android during boot at `/mnt/shared`
- Document shared folder usage in README

## Testing
- `bash -n start-emulator.sh first-boot.sh`
- `docker-compose config`


------
fix #15 