### PR TITLE
fix: remove .lock files to resolve emulator restart crashes

### DIFF
--- a/start-emulator.sh
+++ b/start-emulator.sh
@@ -3,6 +3,9 @@
 # Kill any running emulator instances before starting a new one
 pkill -f "/opt/android-sdk/emulator/emulator"
 
+# Removes .lock files before emulator starts to prevent crashes
+rm -rf /data/android.avd/*.lock
+
 # Use custom ramdisk if present
 if [ -f /data/android.avd/ramdisk.img ]; then
   RAMDISK="-ramdisk /data/android.avd/ramdisk.img"


### PR DESCRIPTION
Added a command to remove .lock files before starting emulator to prevent crashes.
