### PR TITLE
fix: add missing lib for OpenGL to prevent crashing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:20.04
 # Install necessary packages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        libegl1 \
         openjdk-17-jdk-headless \
         wget \
         curl \
@@ -13,17 +14,6 @@ RUN apt-get update && \
         qemu-kvm \
         iproute2 \
         socat \
-		libnss3 \
-		libdbus-1-3 \
-		libasound2 \
-		libpulse0 \
-		libx11-6 libx11-xcb1 \
-		libxcomposite1 libxcursor1 libxdamage1 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
-		libdrm2 libgbm1 \
-		libgl1 \
-		libegl1 libegl1-mesa-dev \
-		libgles2 libgles2-mesa-dev \
-		mesa-utils \
         tzdata && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Following today’s update, my container experienced a crash upon rebooting. The inclusion of these libraries resolved the issue.