### PR TITLE
CI: Link GitHub releases with versioning

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,4 +1,4 @@
-name: Build and Push Docker Image to Docker Hub
+name: Build and Publish Docker Image
 
 on:
   push:
@@ -6,7 +6,10 @@ on:
   pull_request:
     branches: [ main ]
   release:
-    types: [ created ]
+    types: [ published ]
+
+env:
+  IMAGE_NAME: shmayro/dockerify-android
 
 jobs:
   build:
@@ -14,36 +17,85 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
+
+      - name: Prepare Docker metadata
+        id: meta
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          SHA: ${{ github.sha }}
+          REPOSITORY: ${{ github.repository }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease || 'false' }}
+        run: |
+          python3 <<'PY' >> "$GITHUB_OUTPUT"
+          import os
+          import re
+          from datetime import datetime, timezone
+
+          image = os.environ["IMAGE_NAME"]
+          event_name = os.environ["EVENT_NAME"]
+          ref_name = os.environ["REF_NAME"]
+          ref_type = os.environ["REF_TYPE"]
+          sha = os.environ["SHA"]
+          repository = os.environ["REPOSITORY"]
+          prerelease = os.environ.get("RELEASE_PRERELEASE", "false").lower() == "true"
+
+          tags = []
+          version = ref_name
+
+          if event_name == "push" and ref_type == "branch" and ref_name == "main":
+              version = "edge"
+              tags.extend([f"{image}:edge", f"{image}:sha-{sha[:7]}"])
+          elif event_name == "release":
+              version = ref_name.removeprefix("v")
+              tags.append(f"{image}:{version}")
+
+              stable = re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", version)
+              if stable:
+                  major, minor, _patch = version.split(".")
+                  tags.extend([
+                      f"{image}:{major}.{minor}",
+                      f"{image}:{major}",
+                  ])
+                  if not prerelease:
+                      tags.append(f"{image}:latest")
+
+          labels = {
+              "org.opencontainers.image.created": datetime.now(timezone.utc).isoformat(),
+              "org.opencontainers.image.revision": sha,
+              "org.opencontainers.image.source": f"https://github.com/{repository}",
+              "org.opencontainers.image.version": version,
+          }
+
+          print("tags<<EOF")
+          print("\n".join(dict.fromkeys(tags)))
+          print("EOF")
+
+          print("labels<<EOF")
+          print("\n".join(f"{key}={value}" for key, value in labels.items()))
+          print("EOF")
+          PY
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Get current date
-        if: github.ref == 'refs/heads/main'
-        id: date
-        run: echo "DATE=$(date +'%d-%m-%y')" >> $GITHUB_ENV
-
-      - name: Get Pull Request ID
-        if: github.event_name == 'pull_request'
-        id: pr
-        run: echo "PR_ID=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
-
       - name: Build and Push Docker Image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
-          tags: |
-            ${{ github.ref == 'refs/heads/main' && 'shmayro/dockerify-android:latest' || '' }}
-            ${{ github.ref == 'refs/heads/main' && format('shmayro/dockerify-android:{0}', env.DATE) || '' }}
-            ${{ github.event_name == 'pull_request' && format('shmayro/dockerify-android:pr-{0}', env.PR_ID) || '' }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Docker Pulls](https://img.shields.io/docker/pulls/shmayro/dockerify-android)](https://hub.docker.com/r/shmayro/dockerify-android)
+[![GitHub Release](https://img.shields.io/github/v/release/shmayro/dockerify-android)](https://github.com/shmayro/dockerify-android/releases)
 [![GitHub Issues](https://img.shields.io/github/issues/shmayro/dockerify-android)](https://github.com/shmayro/dockerify-android/issues)
 [![GitHub Stars](https://img.shields.io/github/stars/shmayro/dockerify-android?style=social)](https://github.com/shmayro/dockerify-android/stargazers)
 
@@ -38,6 +39,7 @@ Access and control the Android emulator directly in your web browser with the in
   - [Customizing Device Screen](#customizing-device-screen)
 - [First Boot Process](#-first-boot-process)
 - [Container Logs](#-container-logs)
+- [Versioning and Releases](#-versioning-and-releases)
 - [Roadmap](#-roadmap)
 - [Troubleshooting](#-troubleshooting)
 - [Contributing](#-contributing)
@@ -90,6 +92,7 @@ To simplify the setup process, you can use the provided [docker-compose.yml](htt
     ```
 
     > **Note:** This command launches the Android emulator and web interface. First boot takes some time to initialize. Once ready, the device will appear in the web interface at http://localhost:8000.
+
 
 ## 📡 **Usage**
 
@@ -196,6 +199,12 @@ This includes:
 - Supervisor logs
 - Android emulator stdout/stderr
 - First-boot process logs
+
+## 🏷️ **Versioning and Releases**
+
+Dockerify Android uses GitHub Releases as the source of truth for stable project versions. Publishing a release such as `v1.2.3` creates matching Docker image tags: `1.2.3`, `1.2`, `1`, and `latest`.
+
+Builds from the `main` branch are published as development images using `edge` and `sha-<short-sha>` tags.
 
 ## 🚧 **Roadmap**
 


### PR DESCRIPTION
### Motivation
- Improve the GitHub Actions pipeline to use newer action versions and produce deterministic Docker image tags and OCI labels for releases and main branch builds.
- Prevent pushing images for pull requests and centralize image name configuration via an `IMAGE_NAME` env var.
- Document release-based versioning and add a release badge to the `README` so users understand image tagging semantics.

### Description
- Renamed workflow to "Build and Publish Docker Image" and changed release trigger type to `published` while adding `IMAGE_NAME` in the workflow `env`.
- Upgraded actions to `actions/checkout@v4`, `docker/setup-buildx-action@v3`, `docker/login-action@v3`, and `docker/build-push-action@v5`.
- Added a `Prepare Docker metadata` step that runs an embedded Python script to compute `tags` and `labels` (exposed via `steps.meta.outputs`) based on event type, ref, and SHA, including `edge`, `sha-<short>`, semver-derived tags, and `latest` for stable releases.
- Made Docker login conditional to skip on pull requests and configured `build-push-action` to only push when `github.event_name != 'pull_request'`, and to use the generated `tags` and `labels` outputs.
- Updated `README.md` to add a GitHub release badge, a Table of Contents entry, and a `Versioning and Releases` section that explains how `vX.Y.Z` releases map to Docker tags.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a18c1437bc08327b5e2cc84c21c6bca)