### PR TITLE
refactor: self-contained install functions in first-boot.sh

### DIFF
--- a/first-boot.sh
+++ b/first-boot.sh
@@ -56,6 +56,8 @@ install_gapps() {
   adb push gapps-11/app /system
   adb push gapps-11/priv-app /system
   rm -r gapps-11
+  adb reboot
+  adb wait-for-device
   touch /data/.gapps-done
 }
 
@@ -109,6 +111,7 @@ EOF
   '
 
   adb reboot
+  adb wait-for-device
   touch /data/.arm-translation-done
 }
 
@@ -132,32 +135,17 @@ if bool_true "$GAPPS_SETUP" && [ ! -f /data/.gapps-done ]; then gapps_needed=tru
 if bool_true "$ROOT_SETUP" && [ ! -f /data/.root-done ]; then root_needed=true; fi
 if bool_true "$ARM_TRANSLATION" && [ ! -f /data/.arm-translation-done ]; then arm_translation_needed=true; fi
 
-needs_reboot() {
-  # Reboot needed if only GAPPS was installed (no root or ARM translation)
-  [ "$gapps_needed" = true ] && [ "$root_needed" = false ] && [ "$arm_translation_needed" = false ]
-}
-
-# Skip initialization if first boot already completed.
-if [ -f /data/.first-boot-done ]; then
-  if [ "$gapps_needed" = true ]; then
-    install_gapps
-    needs_reboot && adb reboot
-  fi
-  [ "$root_needed" = true ] && install_root
-  [ "$arm_translation_needed" = true ] && install_arm_translation
-  apply_settings
-  copy_extras
-  exit 0
+# Create the AVD on first boot only.
+if [ ! -f /data/.first-boot-done ]; then
+  echo "Init AVD ..."
+  echo "no" | avdmanager create avd -n android -k "system-images;android-30;default;x86_64"
 fi
 
-echo "Init AVD ..."
-echo "no" | avdmanager create avd -n android -k "system-images;android-30;default;x86_64"
-
-if [ "$gapps_needed" = true ]; then
-  install_gapps
-  needs_reboot && adb reboot
-fi
-[ "$root_needed" = true ] && install_root
+# Each install is self-contained: prepares the system, applies its changes,
+# reboots, waits for adbd, then writes its done-marker. Safe to run after the
+# first boot — only the missing markers will fire.
+[ "$gapps_needed" = true ]           && install_gapps
+[ "$root_needed" = true ]            && install_root
 [ "$arm_translation_needed" = true ] && install_arm_translation
 apply_settings
 copy_extras


### PR DESCRIPTION
Follow-up to #41. Cleans up the addon orchestration in `first-boot.sh` so each install function is fully self-contained and the post-first-boot flow is correct by construction.

## Why

In the current code:
- `install_gapps` doesn't reboot itself — it relies on a sibling helper `needs_reboot()` that checks "is anything else about to reboot for me?".
- `install_arm_translation` calls `adb reboot` and then immediately `touch /data/.arm-translation-done`. `adb reboot` returns the moment the command is accepted by adbd, not when reboot completes — so the marker is set while the system is still rebooting. A container killed in that window leaves a "marked done but not actually applied" state on next start.
- The first-boot and post-first-boot paths duplicate the same install sequence in two near-identical blocks.

## Changes

- Each install function does **reboot → `adb wait-for-device` → marker** in that order, so the marker only lands once adbd has come back.
- `needs_reboot()` removed — the reboot decision is now local to each install function rather than crossing function boundaries.
- The duplicate first-boot / post-first-boot branches collapse into one — only `avdmanager create avd` is conditional on `/data/.first-boot-done`.
- This makes it safe to flip e.g. `ARM_TRANSLATION=1` on a container that already booted: restart the container and the upper-branch install runs cleanly to completion.

## Cost

One extra AVD reboot (~25s) in the rare case where both GAPPS and ARM_TRANSLATION are enabled in the same pass, traded for cleaner per-function encapsulation.

## Stacked on

This branch is based on `copilot/add-arm64-support` (#41). PR base is set to that branch so the diff shows only the refactor; once #41 merges, the base will switch to `main` automatically.
